### PR TITLE
Fix undefined reference error

### DIFF
--- a/src/moc/moc.y
+++ b/src/moc/moc.y
@@ -280,7 +280,7 @@ char	*straddSpc( const char *, const char *,
 char	*straddSpc( const char *, const char *,
 		    const char *, const char * );
 
-extern int yydebug;
+//extern int yydebug;
 bool	   lexDebug	   = FALSE;
 int	   lineNo;				// current line number
 bool	   errorControl	   = FALSE;		// controlled errors
@@ -1313,8 +1313,8 @@ int main( int argc, char **argv )
 		displayWarnings = FALSE;
 	    } else if ( opt == "ldbg" ) {	// lex debug output
 		lexDebug = TRUE;
-	    } else if ( opt == "ydbg" ) {	// yacc debug output
-		yydebug = TRUE;
+//	    } else if ( opt == "ydbg" ) {	// yacc debug output
+//		yydebug = TRUE;
 	    } else {
 		error = "Invalid argument";
 	    }


### PR DESCRIPTION
```
CMakeFiles/moc-qt2.dir/mocgen.cpp.o: In function `main':
mocgen.cpp:(.text+0x7dad): undefined reference to `yydebug'
```